### PR TITLE
Fix bug with left is nan, and visual bug.

### DIFF
--- a/src/NavigatorNavigationBar.js
+++ b/src/NavigatorNavigationBar.js
@@ -142,6 +142,10 @@ class NavigatorNavigationBar extends React.Component {
             var props = this._getReusableProps(componentName, index);
             if (component && interpolate[componentName](props.style, amount)) {
                 props.pointerEvents = props.style.opacity === 0 ? 'none' : 'box-none';
+                if (isNaN(props.style.left) === true) {
+                    var {left, ...style} = props.style;
+                    props.style = style;
+                }
                 component.setNativeProps(props);
             }
         }, this);

--- a/src/NavigatorNavigationBarStylesAndroid.js
+++ b/src/NavigatorNavigationBarStylesAndroid.js
@@ -60,7 +60,6 @@ var BASE_STYLES = {
   RightButton: {
     position: 'absolute',
     top: 0,
-    left: 0,
     right: BUTTON_EFFECTIVE_MARGIN,
     overflow: 'hidden',
     alignItems: 'flex-end',

--- a/src/NavigatorNavigationBarStylesIOS.js
+++ b/src/NavigatorNavigationBarStylesIOS.js
@@ -58,7 +58,6 @@ const BASE_STYLES = {
     RightButton: {
         position: 'absolute',
         top: STATUS_BAR_HEIGHT,
-        left: 0,
         right: 0,
         overflow: 'hidden',
         opacity: 1,


### PR DESCRIPTION
Hello, I use this fork of *react-native-deprecated-custom-components* to fix the bug with react-native 0.60.

Except that the resolution you bring to this [commit](https://github.com/AndriiUhryn/react-native-custom-components/commit/19205a563230d588aecc23fe0cb4b84d08356b88) brings a graphical issue.

See in the screenshot, the right button is superposed with the title.
<img width="423" alt="Capture d’écran 2020-05-01 à 12 57 46" src="https://user-images.githubusercontent.com/1654977/80801117-b3c63000-8bab-11ea-9b73-66c99ddb5f6d.png">

I propose, with this pull request, another fix.
